### PR TITLE
Prevent long printer and owner names from overflowing printer list cards

### DIFF
--- a/littleprinter/UI/Printers/PrinterListTableViewCell.swift
+++ b/littleprinter/UI/Printers/PrinterListTableViewCell.swift
@@ -133,11 +133,13 @@ class PrinterListTableViewCell: UITableViewCell {
         nameLabel.snp.makeConstraints { (make) in
             make.top.equalTo(cardImageView).offset(11)
             make.left.equalTo(thumbnail.snp.right).offset(30)
+            make.right.equalTo(shareButton.snp.left)
         }
         
         ownerLabel.snp.makeConstraints { (make) in
             make.top.equalTo(nameLabel.snp.bottom).offset(2)
             make.left.equalTo(nameLabel)
+            make.right.equalTo(cardImageView).offset(-6)
         }
         
         statusLabel.snp.makeConstraints { (make) in


### PR DESCRIPTION
Fixes #16.